### PR TITLE
Update link to Java decoder from Presto to Airlift

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@ This is a re-implementation of Zstandard following the [format specification](ht
 
 | Language     | Author              | URL                                   |
 | ------------ | ------------------- | ------------------------------------- |
-| __Java__ (decoder) | Martin Traverso | https://github.com/prestodb/presto/tree/master/presto-orc/src/main/java/com/facebook/presto/orc/zstd
+| __Java__ (decoder) | Martin Traverso | https://github.com/airlift/aircompressor
 
 
 <br/>


### PR DESCRIPTION
@martint seems to have use the Presto Zstandard code as part of airlift.

Given airlift aircompressor is on Maven Central it makes more sense to use it as the reference of his implementation of Zstd in pure Java.

